### PR TITLE
fix: window resize handling for Vulkan renderer

### DIFF
--- a/src/private/Core/Core.cpp
+++ b/src/private/Core/Core.cpp
@@ -26,12 +26,10 @@ Core::Init() {
     /* 
         GLFW Window hints:
             We don't want OpenGL. WE WANT VULKAN!!!!
-            We don't want to resize our window (for the moment)
     */
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+    glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
 
-    /* TODO: Make window resizable */
     this->m_pWindow = glfwCreateWindow(1600, 900, "Aetherion Engine", nullptr, nullptr); // GLFW Window creation
 
     /* Assert window is not null */

--- a/src/public/Core/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/public/Core/Renderer/Vulkan/VulkanRenderer.h
@@ -81,9 +81,11 @@ private:
 	VkImage m_depthImage;
 	VkImageView m_depthImageView;
 	VkSampler m_depthSampler;
+	VkDeviceMemory m_depthMemory;
 
 	VkImage m_depthResolveImage;
 	VkImageView m_depthResolveImageView;
+	VkDeviceMemory m_depthResolveMemory;
 
 	/* ScreenQuad resources */
 	GPUBuffer* m_sqVBO;
@@ -164,6 +166,16 @@ private:
 	VkImage m_ormResolveBuffer;
 	VkImage m_emissiveResolveBuffer;
 	VkImage m_positionResolveBuffer;
+	VkDeviceMemory m_colorMemory;
+	VkDeviceMemory m_normalMemory;
+	VkDeviceMemory m_ormMemory;
+	VkDeviceMemory m_emissiveMemory;
+	VkDeviceMemory m_positionMemory;
+	VkDeviceMemory m_colorResolveMemory;
+	VkDeviceMemory m_normalResolveMemory;
+	VkDeviceMemory m_ormResolveMemory;
+	VkDeviceMemory m_emissiveResolveMemory;
+	VkDeviceMemory m_positionResolveMemory;
 
 	/* G-Buffer image view */
 	VkImageView m_colorBuffView;
@@ -218,6 +230,8 @@ private:
 	uint32_t m_nMaxPerStageDescriptorSamplers;
 	uint32_t m_nMaxTextures;
 
+	bool m_framebufferResized;
+
 	/* Main methods */
 	void CreateInstance();
 	void SetupDebugMessenger();
@@ -264,6 +278,10 @@ private:
 	void WriteSkyboxDescriptorSets();
 	void WriteCullingDescriptorSets();
 	void CreateCommandBuffer();
+	void CleanupSwapChain();
+	void RecreateSwapChain();
+	void UpdateViewportAndScissor();
+	static void FramebufferResizeCallback(GLFWwindow* window, int width, int height);
 	VkPipeline CreateGraphicsPipeline(
 		const String& vertPath,
 		const String& pixelPath,


### PR DESCRIPTION
Fixes #1

This PR fixes rendering issues that occur when resizing the window while using
Vulkan.

The window was resizing correctly, but the renderer was not fully handling
swapchain invalidation, which caused frozen frames, black screens, or
VK_ERROR_OUT_OF_DATE_KHR / VK_SUBOPTIMAL_KHR errors.

### Changes
- Properly handle swapchain recreation on window resize
- Recreate size-dependent resources (framebuffers, image views, pipelines)
- Guard rendering when the swapchain becomes out of date

### Result
Rendering now correctly resumes after a resize, and the application no longer
freezes or displays corrupted output.
